### PR TITLE
Handle typed date columns

### DIFF
--- a/AddProject.js
+++ b/AddProject.js
@@ -101,7 +101,13 @@ function formatNewProjectRow(sheet, rowNumber, priority, status) {
   
   // Format Due Date column
   const dueDateCell = sheet.getRange(rowNumber, 3);
-  dueDateCell.setNumberFormat('m/d/yyyy');
+  try {
+    dueDateCell.setNumberFormat('m/d/yyyy');
+  } catch (e) {
+    // If the Due Date column is a typed column, setting the number format can
+    // throw a ScriptError. We simply skip formatting in that case.
+    console.warn('Unable to set number format for Due Date column:', e);
+  }
   
   // Set text wrapping for Description, Deliverables, and Notes columns
   const descriptionCell = sheet.getRange(rowNumber, 4);


### PR DESCRIPTION
## Summary
- avoid `ScriptError` when formatting the Due Date column

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849c0744d088322b4e0ff02f5effa26