### PR TITLE
Add owner tracking and reminder emails

### DIFF
--- a/AddProject.js
+++ b/AddProject.js
@@ -7,7 +7,11 @@ function onOpen() {
   const ui = SpreadsheetApp.getUi();
   ui.createMenu('Project Management')
     .addItem('Add New Project', 'openAddProjectDialog')
+    .addItem('Send Reminders', 'sendReminders')
     .addToUi();
+
+  // Ensure the Owners sheet exists
+  ensureOwnersSheet();
 }
 
 function openAddProjectDialog() {

--- a/Code.js
+++ b/Code.js
@@ -7,6 +7,9 @@ function recreateProjectTrackingSheet() {
   // Create a new spreadsheet
   const spreadsheet = SpreadsheetApp.create('Project Tracking - Copy');
   const sheet = spreadsheet.getActiveSheet();
+
+  // Ensure Owners sheet exists in the new spreadsheet
+  ensureOwnersSheet(spreadsheet);
   
   // Rename the sheet to "Project Tracking"
   sheet.setName('Project Tracking');

--- a/Reminders.js
+++ b/Reminders.js
@@ -1,0 +1,57 @@
+function ensureOwnersSheet(ss) {
+  ss = ss || SpreadsheetApp.getActiveSpreadsheet();
+  let sheet = ss.getSheetByName('Owners');
+  if (!sheet) {
+    sheet = ss.insertSheet('Owners');
+    const headers = ['Owner', 'Email', 'First Name', 'Last Name'];
+    sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+    sheet.getRange(1, 1, 1, headers.length).setFontWeight('bold');
+  }
+}
+
+function sendReminders() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const projectSheet = ss.getSheetByName('Project Tracking');
+  const ownersSheet = ss.getSheetByName('Owners');
+  if (!projectSheet || !ownersSheet) {
+    SpreadsheetApp.getUi().alert('Required sheets not found.');
+    return;
+  }
+
+  const ownersData = ownersSheet.getRange(2, 1, ownersSheet.getLastRow() - 1, 4).getValues();
+  const ownersMap = {};
+  ownersData.forEach(function(row) {
+    const [owner, email, firstName, lastName] = row;
+    if (owner) {
+      ownersMap[owner] = { email: email, firstName: firstName, lastName: lastName };
+    }
+  });
+
+  const projectData = projectSheet.getRange(2, 1, projectSheet.getLastRow() - 1, 8).getValues();
+  const projectsByOwner = {};
+  projectData.forEach(function(row) {
+    const owner = row[5];
+    if (!owner) return;
+    if (!projectsByOwner[owner]) {
+      projectsByOwner[owner] = [];
+    }
+    projectsByOwner[owner].push({ project: row[0], status: row[6] });
+  });
+
+  Object.keys(projectsByOwner).forEach(function(owner) {
+    const info = ownersMap[owner];
+    if (!info || !info.email) {
+      return;
+    }
+    const projects = projectsByOwner[owner];
+    let body = 'Hello ' + (info.firstName || owner) + ',\n\nHere is the current status of your projects:\n';
+    projects.forEach(function(p) {
+      body += '- ' + p.project + ': ' + p.status + '\n';
+    });
+    body += '\nRegards,\nProject Tracker';
+    const subject = 'Project Status Reminder';
+    MailApp.sendEmail(info.email, subject, body);
+  });
+
+  SpreadsheetApp.getUi().alert('Reminders sent.');
+}


### PR DESCRIPTION
## Summary
- add Send Reminders command to menu
- create Owners sheet if missing
- create new file to manage owners sheet and send reminder emails
- initialize owners sheet when creating new project tracker spreadsheet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849c0db792c83228c6f0577bb6c5dc9