### PR TITLE
Initialize owners sheet and add spreadsheet dropdowns

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -215,7 +215,10 @@ function recreateProjectTrackingSheet() {
   
   // Add data starting from row 2
   sheet.getRange(2, 1, data.length, data[0].length).setValues(data);
-  
+
+  // Apply dropdown validations
+  applyProjectTrackingValidations(sheet);
+
   // Format the sheet
   formatProjectTrackingSheet(sheet, data.length + 1);
   
@@ -294,6 +297,31 @@ function formatProjectTrackingSheet(sheet, totalRows) {
   
   // Set row heights for better readability
   sheet.setRowHeights(2, totalRows - 1, 60);
+}
+
+// Add dropdown validations for the Project Tracking sheet
+function applyProjectTrackingValidations(sheet) {
+  const ss = sheet.getParent();
+  const maxRows = sheet.getMaxRows() - 1;
+
+  const priorityRule = SpreadsheetApp.newDataValidation()
+    .requireValueInList(['High', 'Medium', 'Low'], true)
+    .build();
+  sheet.getRange(2, 2, maxRows, 1).setDataValidation(priorityRule);
+
+  const statusRule = SpreadsheetApp.newDataValidation()
+    .requireValueInList(['Not Started', 'In Progres', 'Done'], true)
+    .build();
+  sheet.getRange(2, 7, maxRows, 1).setDataValidation(statusRule);
+
+  const ownersSheet = ss.getSheetByName('Owners');
+  if (ownersSheet) {
+    const ownerRange = ownersSheet.getRange('A2:A');
+    const ownerRule = SpreadsheetApp.newDataValidation()
+      .requireValueInRange(ownerRange, true)
+      .build();
+    sheet.getRange(2, 6, maxRows, 1).setDataValidation(ownerRule);
+  }
 }
 
 // Alternative function to create sheet in existing spreadsheet
@@ -375,6 +403,9 @@ function createRecurringTasksSheet() {
 
   sheet.getRange(2, 1, data.length, data[0].length).setValues(data);
 
+  // Apply dropdown validations
+  applyRecurringTasksValidations(sheet);
+
   formatRecurringTasksSheet(sheet, data.length + 1);
 
   sheet.autoResizeColumns(1, headers.length);
@@ -424,6 +455,26 @@ function formatRecurringTasksSheet(sheet, totalRows) {
   sheet.setRowHeights(2, totalRows - 1, 40);
 }
 
+// Add dropdown validations for the Recurring Tasks sheet
+function applyRecurringTasksValidations(sheet) {
+  const ss = sheet.getParent();
+  const maxRows = sheet.getMaxRows() - 1;
+
+  const statusRule = SpreadsheetApp.newDataValidation()
+    .requireValueInList(['Not Started', 'In Progres', 'Done'], true)
+    .build();
+  sheet.getRange(2, 6, maxRows, 1).setDataValidation(statusRule);
+
+  const ownersSheet = ss.getSheetByName('Owners');
+  if (ownersSheet) {
+    const ownerRange = ownersSheet.getRange('A2:A');
+    const ownerRule = SpreadsheetApp.newDataValidation()
+      .requireValueInRange(ownerRange, true)
+      .build();
+    sheet.getRange(2, 5, maxRows, 1).setDataValidation(ownerRule);
+  }
+}
+
 function testRecreateRecurringSheet() {
   createRecurringTasksSheet();
 }
@@ -432,5 +483,5 @@ function testRecreateRecurringSheet() {
 function initializeAllSheets() {
   recreateProjectTrackingSheet();
   createRecurringTasksSheet();
-  ensureOwnersSheet();
+  initializeOwnersSheet();
 }

--- a/README.md
+++ b/README.md
@@ -7,5 +7,8 @@ This repository contains Google Apps Script code for managing project and task t
 - **recreateProjectTrackingSheet** – creates or refreshes a "Project Tracking" sheet in the active spreadsheet with sample data.
 - **createRecurringTasksSheet** – creates or refreshes a "Recurring Tasks" sheet for scheduling repeating tasks in the active spreadsheet.
 - **initializeAllSheets** – sets up the Project Tracking, Recurring Tasks, and Owners sheets in the active spreadsheet.
+- **initializeOwnersSheet** – recreates the Owners sheet with example data and header formatting.
+
+All creation scripts now apply data validation drop-downs. Priority and Status columns use predefined lists while Owner selections reference the **Owners** sheet.
 
 Each script formats the sheet with headers, example rows, and color-coded statuses without generating a separate file.

--- a/Reminders.js
+++ b/Reminders.js
@@ -9,6 +9,30 @@ function ensureOwnersSheet(ss) {
   }
 }
 
+// Completely (re)create the Owners sheet with some sample data
+function initializeOwnersSheet() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  let sheet = ss.getSheetByName('Owners');
+  if (sheet) {
+    sheet.clear();
+  } else {
+    sheet = ss.insertSheet('Owners');
+  }
+
+  const headers = ['Owner', 'Email', 'First Name', 'Last Name'];
+  sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+  sheet.getRange(1, 1, 1, headers.length).setFontWeight('bold');
+
+  const data = [
+    ['Justin', '', 'Justin', ''],
+    ['PWA', '', 'PWA', ''],
+    ['Naokimi', '', 'Naokimi', '']
+  ];
+
+  sheet.getRange(2, 1, data.length, data[0].length).setValues(data);
+  sheet.autoResizeColumns(1, headers.length);
+}
+
 function sendReminders() {
   const ss = SpreadsheetApp.getActiveSpreadsheet();
   const projectSheet = ss.getSheetByName('Project Tracking');


### PR DESCRIPTION
## Summary
- allow Owners sheet to be rebuilt with example data
- apply dropdown validations when creating tracking sheets
- call `initializeOwnersSheet` from the overall initializer
- document the new function and validations

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684a03428f608322a189c3e0f5372fbe