### PR TITLE
Resolve Owners sheet init duplication

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -19,45 +19,6 @@ function initializeAllSheets() {
 }
 
 /**
- * Creates and populates the 'Owners' sheet.
- * This sheet serves as the source for the owner dropdowns in other sheets.
- */
-function initializeOwnersSheet() {
-  const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
-  const sheetName = 'Owners';
-  let sheet = spreadsheet.getSheetByName(sheetName);
-
-  if (!sheet) {
-    sheet = spreadsheet.insertSheet(sheetName);
-  } else {
-    sheet.clear(); // Clear existing content to ensure a fresh start
-  }
-
-  // Set up headers
-  const headers = ['Owner Name'];
-  const headerRange = sheet.getRange(1, 1);
-  headerRange.setValue(headers[0])
-             .setFontWeight('bold')
-             .setBackground('#e6f3ff');
-
-  // Set up owner data
-  const ownersData = [
-    ['Justin'],
-    ['PWA'],
-    ['Naokimi'],
-    ['Other']
-  ];
-
-  if (ownersData.length > 0) {
-    sheet.getRange(2, 1, ownersData.length, 1).setValues(ownersData);
-  }
-
-  sheet.autoResizeColumn(1);
-  sheet.setFrozenRows(1);
-  console.log('Owners sheet initialized.');
-}
-
-/**
  * Recreates the "Project Tracking" sheet with a predefined structure and data.
  */
 function recreateProjectTrackingSheet() {

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains Google Apps Script code for managing project and task t
 - **recreateProjectTrackingSheet** – creates or refreshes a "Project Tracking" sheet in the active spreadsheet with sample data.
 - **createRecurringTasksSheet** – creates or refreshes a "Recurring Tasks" sheet for scheduling repeating tasks in the active spreadsheet.
 - **initializeAllSheets** – sets up the Project Tracking, Recurring Tasks, and Owners sheets in the active spreadsheet.
-- **initializeOwnersSheet** – recreates the Owners sheet with example data and header formatting.
+- **initializeOwnersSheet** – recreates the Owners sheet with `Owner`, `Email`, `First Name`, and `Last Name` columns.
 
 All creation scripts now apply data validation drop-downs. Priority and Status columns use predefined lists while Owner selections reference the **Owners** sheet.
 


### PR DESCRIPTION
## Summary
- remove duplicate `initializeOwnersSheet` in `Code.js`
- use the four-column version from `Reminders.js`
- document the owners sheet columns in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684cdda9d0008322a7b3f930bf714d3f