### PR TITLE
Improve sheet styles

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -153,23 +153,44 @@ function formatProjectTrackingSheet(sheet) {
  * @param {GoogleAppsScript.Spreadsheet.Sheet} sheet The sheet to format.
  */
 function formatRecurringTasksSheet(sheet) {
-  const numRows = sheet.getLastRow() - 1;
+  const lastRow = sheet.getLastRow();
+  const lastColumn = sheet.getLastColumn();
+  const numRows = lastRow - 1;
   if (numRows <= 0) return;
 
   const statusRange = sheet.getRange(2, 6, numRows, 1);
+  const dueDateRange = sheet.getRange(2, 4, numRows, 1);
   const rules = [
     SpreadsheetApp.newConditionalFormatRule().whenTextEqualTo('Done').setBackground('#e8f5e8').setRanges([statusRange]).build(),
     SpreadsheetApp.newConditionalFormatRule().whenTextEqualTo('In Progress').setBackground('#fff3e0').setRanges([statusRange]).build(),
-    SpreadsheetApp.newConditionalFormatRule().whenTextEqualTo('Not Started').setBackground('#ffebee').setRanges([statusRange]).build()
+    SpreadsheetApp.newConditionalFormatRule().whenTextEqualTo('Not Started').setBackground('#ffebee').setRanges([statusRange]).build(),
+    SpreadsheetApp.newConditionalFormatRule().whenDateBefore(SpreadsheetApp.RelativeDate.YESTERDAY).setBackground('#ffcccc').setRanges([dueDateRange]).build()
   ];
   sheet.setConditionalFormatRules(rules);
   
   // Apply other formatting
+  sheet.getRange(1, 1, 1, lastColumn)
+       .setFontColor('#1a73e8')
+       .setFontSize(12)
+       .setFontWeight('bold');
+
+  sheet.setFrozenColumns(1);
+
   sheet.getRange(2, 4, numRows, 1).setNumberFormat('m/d/yyyy'); // Next Due Date
   sheet.getRange(2, 7, numRows, 1).setNumberFormat('m/d/yyyy'); // Last Completed
   sheet.getRange(2, 8, numRows, 1).setWrap(true); // Notes
-  sheet.getRange(1, 1, sheet.getLastRow(), sheet.getLastColumn()).setBorder(true, true, true, true, true, true);
-  sheet.setRowHeights(2, numRows, 40);
+
+  sheet.getRange(1, 1, lastRow, lastColumn).setBorder(true, true, true, true, true, true);
+  if (numRows > 0) {
+    sheet.setRowHeights(2, numRows, 40);
+  }
+
+  sheet.getBandings().forEach(function(b) { b.remove(); });
+  if (numRows > 0) {
+    sheet.getRange(2, 1, numRows, lastColumn).applyRowBanding(SpreadsheetApp.BandingTheme.LIGHT_GREY);
+  }
+
+  sheet.getRange(1, 1, lastRow, lastColumn).createFilter();
 }
 
 

--- a/Reminders.js
+++ b/Reminders.js
@@ -6,6 +6,7 @@ function ensureOwnersSheet(ss) {
     const headers = ['Owner', 'Email', 'First Name', 'Last Name'];
     sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
     sheet.getRange(1, 1, 1, headers.length).setFontWeight('bold');
+    formatOwnersSheet(sheet);
   }
 }
 
@@ -30,7 +31,7 @@ function initializeOwnersSheet() {
   ];
 
   sheet.getRange(2, 1, data.length, data[0].length).setValues(data);
-  sheet.autoResizeColumns(1, headers.length);
+  formatOwnersSheet(sheet);
 }
 
 function sendReminders() {
@@ -78,4 +79,40 @@ function sendReminders() {
   });
 
   SpreadsheetApp.getUi().alert('Reminders sent.');
+}
+
+/**
+ * Applies consistent formatting to the Owners sheet for better readability.
+ * @param {GoogleAppsScript.Spreadsheet.Sheet} sheet The Owners sheet.
+ */
+function formatOwnersSheet(sheet) {
+  const lastColumn = sheet.getLastColumn();
+  const lastRow = sheet.getLastRow();
+
+  // Style header row
+  sheet.getRange(1, 1, 1, lastColumn)
+       .setBackground('#e6f3ff')
+       .setFontWeight('bold')
+       .setFontColor('#1a73e8')
+       .setFontSize(12);
+
+  // Freeze header row
+  sheet.setFrozenRows(1);
+
+  // Remove existing banding and apply new light grey banding
+  sheet.getBandings().forEach(function(b) { b.remove(); });
+  if (lastRow > 1) {
+    sheet.getRange(2, 1, lastRow - 1, lastColumn)
+         .applyRowBanding(SpreadsheetApp.BandingTheme.LIGHT_GREY);
+  }
+
+  // Add borders
+  sheet.getRange(1, 1, Math.max(lastRow, 1), lastColumn)
+       .setBorder(true, true, true, true, true, true);
+
+  // Standard row height and auto size columns
+  if (lastRow > 0) {
+    sheet.setRowHeights(2, lastRow - 1, 30);
+  }
+  sheet.autoResizeColumns(1, lastColumn);
 }


### PR DESCRIPTION
## Summary
- add `formatOwnersSheet` helper to stylize the Owners sheet
- call new formatting when creating Owners sheet
- enhance `formatRecurringTasksSheet` with better styles, row banding, filters, and overdue highlighting

## Testing
- `node --check Code.js`
- `node --check Reminders.js`
- `node --check AddProject.js`


------
https://chatgpt.com/codex/tasks/task_e_684cdef777908322b80ea1632bb54331