### PR TITLE
Enhance reminders and add quick guide

### DIFF
--- a/AddProject.js
+++ b/AddProject.js
@@ -9,6 +9,7 @@ function onOpen() {
     .addItem('Add New Project', 'openAddProjectDialog')
     .addItem('Send Reminders', 'sendReminders')
     .addItem('Initialize Sheets', 'initializeAllSheets')
+    .addItem('Quick Guide', 'openQuickGuide')
     .addToUi();
 
   // Ensure the Owners sheet exists
@@ -21,8 +22,16 @@ function openAddProjectDialog() {
     .setWidth(600)
     .setHeight(700)
     .setTitle('Add New Project');
-  
+
   SpreadsheetApp.getUi().showModalDialog(htmlOutput, 'Add New Project');
+}
+
+function openQuickGuide() {
+  const htmlOutput = HtmlService.createHtmlOutputFromFile('QuickGuide')
+    .setWidth(500)
+    .setHeight(400)
+    .setTitle('Quick Guide');
+  SpreadsheetApp.getUi().showModalDialog(htmlOutput, 'Quick Guide');
 }
 
 function addNewProject(projectData) {

--- a/QuickGuide.html
+++ b/QuickGuide.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base target="_top">
+  <style>
+    body {font-family: Arial, sans-serif; padding: 20px;}
+    h2 {color:#1a73e8;}
+  </style>
+</head>
+<body>
+  <h2>Project Tracker Quick Guide</h2>
+  <ul>
+    <li><b>Add New Project</b> - open a form to add a project to the tracker.</li>
+    <li><b>Send Reminders</b> - email each owner a summary of their projects.</li>
+    <li><b>Initialize Sheets</b> - recreate sample sheets and formatting.</li>
+  </ul>
+  <p>Use the <b>Project Tracking</b> sheet for full project details.</p>
+</body>
+</html>

--- a/Reminders.js
+++ b/Reminders.js
@@ -63,25 +63,28 @@ function sendReminders() {
     }
     projectsByOwner[owner].push({
       project: row[0], // Project Name from column A
+      dueDate: row[2], // Due Date from column C
       status: row[6]   // Status from column G
     });
   });
 
   let remindersSentCount = 0;
+  const sheetLink = ss.getUrl() + '#gid=' + projectSheet.getSheetId();
   Object.keys(projectsByOwner).forEach(function(owner) {
     const info = ownersMap[owner];
     if (!info || !info.email) {
       console.log('Skipping reminder for ' + owner + ' due to missing email.');
       return; // Skip this owner if no email is listed
     }
-    
+
     const projects = projectsByOwner[owner];
     let body = 'Hello ' + (info.firstName || owner) + ',\n\nHere is the current status of your projects:\n';
     projects.forEach(function(p) {
-      body += '- ' + p.project + ': ' + p.status + '\n';
+      const due = p.dueDate ? Utilities.formatDate(new Date(p.dueDate), ss.getSpreadsheetTimeZone(), 'MM/dd/yyyy') : 'No due date';
+      body += '- ' + p.project + ' (Due: ' + due + '): ' + p.status + '\n';
     });
-    body += '\nRegards,\nProject Tracker';
-    
+    body += '\nCheck project sheet for more details:\n' + sheetLink + '\n\nRegards,\nProject Tracker';
+
     const subject = 'Project Status Reminder';
     MailApp.sendEmail(info.email, subject, body);
     remindersSentCount++;


### PR DESCRIPTION
## Summary
- include due dates and sheet link in reminder emails
- add Quick Guide dialog and menu option

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851cfef14dc83228ccff1a16bcebc39