### PR TITLE
Skip reminders for completed projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains Google Apps Script code for managing project and task t
 - **createRecurringTasksSheet** – creates or refreshes a "Recurring Tasks" sheet for scheduling repeating tasks in the active spreadsheet.
 - **initializeAllSheets** – sets up the Project Tracking, Recurring Tasks, and Owners sheets in the active spreadsheet.
 - **initializeOwnersSheet** – recreates the Owners sheet with `Owner`, `Email`, `First Name`, and `Last Name` columns.
+- **sendReminders** – emails each owner a list of their active projects and recurring tasks. Owners without active projects are skipped and projects marked **Done** are omitted from the emails.
 
 All creation scripts now apply data validation drop-downs. Priority and Status columns use predefined lists while Owner selections reference the **Owners** sheet.
 

--- a/Reminders.js
+++ b/Reminders.js
@@ -97,19 +97,28 @@ function sendReminders() {
     }
 
     const projects = projectsByOwner[owner] || [];
+    // Exclude projects marked as Done
+    const activeProjects = projects.filter(function(p) {
+      return String(p.status).toLowerCase() !== 'done';
+    });
+    // Skip sending if owner has no active projects
+    if (activeProjects.length === 0) {
+      console.log('Skipping reminder for ' + owner + ' due to no active projects.');
+      return;
+    }
     const tasks = tasksByOwner[owner] || [];
 
     let body = 'Hello ' + (info.firstName || owner) + ',\n\n';
-    if (projects.length > 0) {
+    if (activeProjects.length > 0) {
       body += 'Here is the current status of your projects:\n';
-      projects.forEach(function(p) {
+      activeProjects.forEach(function(p) {
         const due = p.dueDate ? Utilities.formatDate(new Date(p.dueDate), ss.getSpreadsheetTimeZone(), 'MM/dd/yyyy') : 'No due date';
         body += '- ' + p.project + ' (Due: ' + due + '): ' + p.status + '\n';
       });
     }
 
     if (tasks.length > 0) {
-      if (projects.length > 0) body += '\n';
+      if (activeProjects.length > 0) body += '\n';
       body += 'Recurring tasks:\n';
       tasks.forEach(function(t) {
         const due = t.nextDue ? Utilities.formatDate(new Date(t.nextDue), ss.getSpreadsheetTimeZone(), 'MM/dd/yyyy') : 'No due date';


### PR DESCRIPTION
## Summary
- ignore projects marked as **Done** when building reminder emails
- skip sending reminders if an owner has no active projects
- document reminder behavior in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b3f7584748322b4ad3ca01937e7a9